### PR TITLE
fix crash on debug

### DIFF
--- a/src/protocols/ios/ios.ts
+++ b/src/protocols/ios/ios.ts
@@ -340,14 +340,14 @@ export abstract class IOSProtocol extends ProtocolAdapter {
     private onRuntimeGetProperties(msg: any): Promise<any> {
         const newPropertyDescriptors = [];
 
-        for (let i = 0; i < msg.result.result.length; i++) {
-            if (msg.result.result[i].isOwn || msg.result.result[i].nativeGetter) {
-                msg.result.result[i].isOwn = true;
-                newPropertyDescriptors.push(msg.result.result[i]);
+        for (let i = 0; i < msg.result.properties.length; i++) {
+            if (msg.result.properties[i].isOwn || msg.result.properties[i].nativeGetter) {
+                msg.result.properties[i].isOwn = true;
+                newPropertyDescriptors.push(msg.result.properties[i]);
             }
         }
-        msg.result.result = null;
-        msg.result.result = newPropertyDescriptors;
+        msg.result.properties = null;
+        msg.result.properties = newPropertyDescriptors;
 
         return Promise.resolve(msg);
     }


### PR DESCRIPTION
use result.properties to instead result.result because it's undefined